### PR TITLE
feat: implement platform collapse + chaos events (Team 2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
   <script src="js/utils/SpriteFactory.js"></script>
   <script src="js/systems/InputManager.js"></script>
   <script src="js/entities/Player.js"></script>
+  <script src="js/entities/Platform.js"></script>
+  <script src="js/systems/ChaosEventSystem.js"></script>
   <script src="js/scenes/BootScene.js"></script>
   <script src="js/scenes/GameScene.js"></script>
 </body>

--- a/js/entities/Platform.js
+++ b/js/entities/Platform.js
@@ -1,0 +1,110 @@
+(function () {
+  'use strict';
+
+  // ---- Platform Collapse System ----
+  // Extends the existing static platform group members with collapse mechanics.
+  // Does NOT modify how platforms are created in GameScene — only adds collapse
+  // behaviour that is called from GameScene.updatePlatforms(delta).
+
+  // Collapse timing constants
+  var COLLAPSE_WARNING_DURATION = 2000;  // 2 seconds of warning flash before collapse
+  var COLLAPSE_FLASH_INTERVAL = 150;     // flash toggle interval in ms during warning
+  var FIRST_COLLAPSE_DELAY = 20000;      // ~20 seconds into match before first collapse
+  var COLLAPSE_STAGGER_INTERVAL = 8000;  // seconds between successive collapses
+
+  // Priority tiers — lower number = collapses sooner (outer/less important first)
+  // Maps AP.PLATFORMS index to collapse priority tier.
+  // Outer platforms (corners, edges) are tier 1, mid platforms tier 2, central tier 3.
+  var COLLAPSE_PRIORITY = [
+    1,  // 0: bottom-left        (outer)
+    1,  // 1: bottom-right       (outer)
+    2,  // 2: center-low         (mid)
+    2,  // 3: mid-left           (mid)
+    2,  // 4: mid-right          (mid)
+    3,  // 5: center-mid         (central)
+    1,  // 6: upper-left         (outer)
+    1,  // 7: upper-right        (outer)
+    3,  // 8: top-center         (central)
+  ];
+
+  /**
+   * Initialise collapse state on a platform sprite.
+   * Called once per platform after the static group is built in GameScene.
+   * @param {Phaser.Physics.Arcade.Sprite} plat - The platform sprite
+   * @param {number} index - Index into AP.PLATFORMS (used for priority lookup)
+   */
+  function initCollapseState(plat, index) {
+    plat._collapseState = 'stable';        // stable | warning | collapsed
+    plat._collapseTimer = 0;               // accumulator for warning phase
+    plat._flashTimer = 0;                   // accumulator for flash toggle
+    plat._collapseIndex = index;
+    plat._collapsePriority = (index < COLLAPSE_PRIORITY.length)
+      ? COLLAPSE_PRIORITY[index]
+      : 2; // default mid-tier for any extra platforms
+    plat._originalAlpha = plat.alpha;
+  }
+
+  /**
+   * Begin the 2-second warning flash on a platform.
+   * Safe to call multiple times — only triggers if the platform is still stable.
+   * @param {Phaser.Scene} scene - The current Phaser scene (for tweens)
+   * @param {Phaser.Physics.Arcade.Sprite} plat - The platform sprite
+   */
+  function startCollapse(scene, plat) {
+    if (!plat || plat._collapseState !== 'stable') return;
+    plat._collapseState = 'warning';
+    plat._collapseTimer = 0;
+    plat._flashTimer = 0;
+
+    // Tint the platform red during warning
+    plat.setTint(0xff4444);
+  }
+
+  /**
+   * Instantly collapse a platform — disable physics body and hide sprite.
+   * @param {Phaser.Physics.Arcade.Sprite} plat - The platform sprite
+   */
+  function collapse(plat) {
+    if (!plat || plat._collapseState === 'collapsed') return;
+    plat._collapseState = 'collapsed';
+    plat.body.enable = false;
+    plat.setVisible(false);
+    plat.setActive(false);
+    plat.clearTint();
+  }
+
+  /**
+   * Returns an array of platform sprites that have NOT collapsed.
+   * @param {Phaser.Physics.Arcade.StaticGroup} platformGroup
+   * @returns {Phaser.Physics.Arcade.Sprite[]}
+   */
+  function getActivePlatforms(platformGroup) {
+    var active = [];
+    var children = platformGroup.getChildren();
+    for (var i = 0; i < children.length; i++) {
+      // Only include platforms that have collapse state initialised and are not collapsed.
+      // Boundary segments do not have _collapseState, so they are excluded.
+      if (children[i]._collapseState && children[i]._collapseState !== 'collapsed') {
+        active.push(children[i]);
+      }
+    }
+    return active;
+  }
+
+  // ---- Expose on AP namespace ----
+  AP.PlatformCollapse = {
+    COLLAPSE_WARNING_DURATION: COLLAPSE_WARNING_DURATION,
+    COLLAPSE_FLASH_INTERVAL: COLLAPSE_FLASH_INTERVAL,
+    FIRST_COLLAPSE_DELAY: FIRST_COLLAPSE_DELAY,
+    COLLAPSE_STAGGER_INTERVAL: COLLAPSE_STAGGER_INTERVAL,
+    initCollapseState: initCollapseState,
+    startCollapse: startCollapse,
+    collapse: collapse,
+    getActivePlatforms: getActivePlatforms
+  };
+
+  // Also expose getActivePlatforms on ChaosEventSystem namespace so Coder B can call it
+  AP.ChaosEventSystem = AP.ChaosEventSystem || {};
+  AP.ChaosEventSystem.getActivePlatforms = null; // will be bound in GameScene after platforms are built
+
+})();

--- a/js/scenes/GameScene.js
+++ b/js/scenes/GameScene.js
@@ -22,6 +22,7 @@
       this._buildBoundary(0, 0, size, BOUNDARY_THICKNESS);                           // ceiling
 
       // --- Platforms from config ---
+      this._platformSprites = [];
       for (var i = 0; i < AP.PLATFORMS.length; i++) {
         var p = AP.PLATFORMS[i];
         var pw = p.width * size;
@@ -30,7 +31,23 @@
         var plat = this.platforms.create(px, py, 'platform');
         plat.setDisplaySize(pw, AP.PLATFORM_HEIGHT);
         plat.refreshBody();
+        // Initialise collapse state (Team 2 Coder A)
+        AP.PlatformCollapse.initCollapseState(plat, i);
+        this._platformSprites.push(plat);
       }
+
+      // --- Platform collapse system state (Team 2 Coder A) ---
+      this._matchTime = 0;
+      this._collapseQueue = this._buildCollapseQueue();
+      this._nextCollapseIndex = 0;
+      this._nextCollapseTime = AP.PlatformCollapse.FIRST_COLLAPSE_DELAY;
+
+      // Expose getActivePlatforms for ChaosEventSystem (Team 2 Coder B)
+      var platformGroup = this.platforms;
+      AP.ChaosEventSystem = AP.ChaosEventSystem || {};
+      AP.ChaosEventSystem.getActivePlatforms = function () {
+        return AP.PlatformCollapse.getActivePlatforms(platformGroup);
+      };
 
       // --- Player ---
       this.player = new AP.Player(this, size * 0.5, size * 0.7);
@@ -40,6 +57,9 @@
 
       // Store for update
       this.boundaryThickness = BOUNDARY_THICKNESS;
+
+      // --- Chaos event system (Team 2 Coder B) ---
+      this.setupChaos();
     },
 
     _buildBoundary: function (edgeX, edgeY, edgeW, edgeH) {
@@ -77,6 +97,88 @@
           AP.gameSize,
           this.boundaryThickness
         );
+      }
+      this.updatePlatforms(delta);
+      this.updateChaos(time, delta);
+    },
+
+    // --- Team 2 Coder B: Chaos events ---
+
+    setupChaos: function () {
+      this.chaosSystem = new AP.ChaosEventSystem(this);
+    },
+
+    updateChaos: function (time, delta) {
+      if (this.chaosSystem) {
+        this.chaosSystem.update(time, delta);
+      }
+    },
+
+    // --- Team 2 Coder A: Platform collapse ---
+
+    /**
+     * Build the collapse queue sorted by priority (outer first, central last).
+     * Within the same priority tier, order is randomised for variety.
+     */
+    _buildCollapseQueue: function () {
+      var sprites = this._platformSprites.slice();
+
+      // Shuffle first so same-tier order is random
+      for (var i = sprites.length - 1; i > 0; i--) {
+        var j = Math.floor(Math.random() * (i + 1));
+        var tmp = sprites[i];
+        sprites[i] = sprites[j];
+        sprites[j] = tmp;
+      }
+
+      // Stable-sort by priority tier (lower tier = earlier collapse)
+      sprites.sort(function (a, b) {
+        return a._collapsePriority - b._collapsePriority;
+      });
+
+      return sprites;
+    },
+
+    /**
+     * updatePlatforms(delta) — called every frame from update().
+     * Manages staggered collapse timers and warning flash animations.
+     */
+    updatePlatforms: function (delta) {
+      this._matchTime += delta;
+
+      // --- Trigger next collapse in queue ---
+      if (this._nextCollapseIndex < this._collapseQueue.length &&
+          this._matchTime >= this._nextCollapseTime) {
+
+        var target = this._collapseQueue[this._nextCollapseIndex];
+        // Only start collapse if the platform is still stable (might already be
+        // collapsing from a Meteor Strike chaos event).
+        if (target._collapseState === 'stable') {
+          AP.PlatformCollapse.startCollapse(this, target);
+        }
+        this._nextCollapseIndex++;
+        this._nextCollapseTime += AP.PlatformCollapse.COLLAPSE_STAGGER_INTERVAL;
+      }
+
+      // --- Update warning flash and collapse for all platforms ---
+      var children = this._platformSprites;
+      for (var i = 0; i < children.length; i++) {
+        var p = children[i];
+        if (p._collapseState === 'warning') {
+          p._collapseTimer += delta;
+          p._flashTimer += delta;
+
+          // Toggle visibility to create blinking effect
+          if (p._flashTimer >= AP.PlatformCollapse.COLLAPSE_FLASH_INTERVAL) {
+            p._flashTimer -= 150;
+            p.setAlpha(p.alpha < 1 ? 1 : 0.2);
+          }
+
+          // Warning phase over — collapse the platform
+          if (p._collapseTimer >= AP.PlatformCollapse.COLLAPSE_WARNING_DURATION) {
+            AP.PlatformCollapse.collapse(p);
+          }
+        }
       }
     }
   });

--- a/js/systems/ChaosEventSystem.js
+++ b/js/systems/ChaosEventSystem.js
@@ -1,0 +1,354 @@
+(function () {
+  'use strict';
+
+  // -----------------------------------------------------------
+  // ChaosEventSystem — fires a random chaos event every ~20s
+  // -----------------------------------------------------------
+  // Events set flags / overlays so other systems (GravitySystem,
+  // BlackHole) can read them in Phase 3 without tight coupling.
+  // -----------------------------------------------------------
+
+  var EVENT_INTERVAL = 20000;          // ms between events (~20s)
+  var EVENT_INTERVAL_VARIANCE = 4000;  // +/- jitter so timing isn't predictable
+
+  // Per-event durations (ms)
+  var GRAVITY_SURGE_DURATION   = 4000;
+  var BLACKOUT_DURATION        = 3000;
+  var EVENT_HORIZON_DURATION   = 2000;
+  var VACUUM_VENT_DURATION     = 3000;
+
+  var VACUUM_FORCE = 180; // px/s directional push
+
+  // Announcement display time (ms)
+  var ANNOUNCE_DURATION = 2000;
+
+  // All event names — order matters only for the random picker
+  var EVENT_NAMES = [
+    'gravitySurge',
+    'blackout',
+    'meteorStrike',
+    'eventHorizonFlash',
+    'vacuumVent'
+  ];
+
+  // Human-readable labels shown on screen
+  var EVENT_LABELS = {
+    gravitySurge:      'GRAVITY SURGE',
+    blackout:          'BLACKOUT',
+    meteorStrike:      'METEOR STRIKE',
+    eventHorizonFlash: 'EVENT HORIZON FLASH',
+    vacuumVent:        'VACUUM VENT'
+  };
+
+  // -------------------------------------------------------
+  // Constructor
+  // -------------------------------------------------------
+  function ChaosEventSystem(scene) {
+    this.scene = scene;
+
+    // Active-event timers: { eventName: endTime (scene time in ms) }
+    this._activeEvents = {};
+
+    // Next event fires at this scene-time
+    this._nextEventTime = EVENT_INTERVAL + this._jitter();
+
+    // Vacuum vent directional vector (unit-length cardinal)
+    this._vacuumDir = { x: 0, y: 0 };
+
+    // Blackout overlay (created lazily on first blackout)
+    this._blackoutOverlay = null;
+
+    // Announcement text object (reused)
+    this._announceText = null;
+    this._announceEndTime = 0;
+  }
+
+  // -------------------------------------------------------
+  // Public API (instance methods)
+  // -------------------------------------------------------
+
+  /** Returns true while the named event is in effect. */
+  ChaosEventSystem.prototype.isActive = function (eventName) {
+    return !!this._activeEvents[eventName];
+  };
+
+  /** Returns the current vacuum vent direction vector (or {x:0,y:0}). */
+  ChaosEventSystem.prototype.getVacuumDir = function () {
+    if (this.isActive('vacuumVent')) {
+      return { x: this._vacuumDir.x, y: this._vacuumDir.y };
+    }
+    return { x: 0, y: 0 };
+  };
+
+  /** Returns the vacuum force magnitude (px/s). */
+  ChaosEventSystem.prototype.getVacuumForce = function () {
+    return VACUUM_FORCE;
+  };
+
+  // -------------------------------------------------------
+  // Per-frame update — called from GameScene.updateChaos()
+  // -------------------------------------------------------
+  ChaosEventSystem.prototype.update = function (time, delta) {
+    this._delta = delta || 16;
+    // --- Expire finished events ---
+    var names = Object.keys(this._activeEvents);
+    for (var i = 0; i < names.length; i++) {
+      if (time >= this._activeEvents[names[i]]) {
+        this._endEvent(names[i]);
+      }
+    }
+
+    // --- Fire next event if it's time ---
+    if (time >= this._nextEventTime) {
+      this._fireRandomEvent(time);
+      this._nextEventTime = time + EVENT_INTERVAL + this._jitter();
+    }
+
+    // --- Update ongoing effects ---
+    this._updateVacuumVent();
+    this._updateAnnouncement(time);
+  };
+
+  // -------------------------------------------------------
+  // Random event picker
+  // -------------------------------------------------------
+  ChaosEventSystem.prototype._fireRandomEvent = function (time) {
+    var idx = Math.floor(Math.random() * EVENT_NAMES.length);
+    var name = EVENT_NAMES[idx];
+    this._startEvent(name, time);
+  };
+
+  // -------------------------------------------------------
+  // Start / end dispatchers
+  // -------------------------------------------------------
+  ChaosEventSystem.prototype._startEvent = function (name, time) {
+    switch (name) {
+      case 'gravitySurge':
+        this._activeEvents[name] = time + GRAVITY_SURGE_DURATION;
+        break;
+
+      case 'blackout':
+        this._activeEvents[name] = time + BLACKOUT_DURATION;
+        this._showBlackout();
+        break;
+
+      case 'meteorStrike':
+        this._doMeteorStrike();
+        // Meteor Strike is instantaneous — no duration tracking needed
+        break;
+
+      case 'eventHorizonFlash':
+        this._activeEvents[name] = time + EVENT_HORIZON_DURATION;
+        break;
+
+      case 'vacuumVent':
+        this._activeEvents[name] = time + VACUUM_VENT_DURATION;
+        this._startVacuumVent();
+        break;
+    }
+
+    this._showAnnouncement(name, time);
+  };
+
+  ChaosEventSystem.prototype._endEvent = function (name) {
+    delete this._activeEvents[name];
+
+    switch (name) {
+      case 'blackout':
+        this._hideBlackout();
+        break;
+      case 'vacuumVent':
+        this._stopVacuumVent();
+        break;
+      // gravitySurge and eventHorizonFlash just clear their flags —
+      // other systems check isActive() each frame.
+    }
+  };
+
+  // -------------------------------------------------------
+  // Event implementations
+  // -------------------------------------------------------
+
+  // -- Blackout --
+  ChaosEventSystem.prototype._showBlackout = function () {
+    var scene = this.scene;
+    var size = AP.gameSize;
+    if (!this._blackoutOverlay) {
+      this._blackoutOverlay = scene.add.rectangle(
+        size / 2, size / 2,
+        size, size,
+        0x000000, 0.92
+      );
+      this._blackoutOverlay.setDepth(900); // above most things, below announcements
+    }
+    this._blackoutOverlay.setVisible(true);
+  };
+
+  ChaosEventSystem.prototype._hideBlackout = function () {
+    if (this._blackoutOverlay) {
+      this._blackoutOverlay.setVisible(false);
+    }
+  };
+
+  // -- Meteor Strike --
+  ChaosEventSystem.prototype._doMeteorStrike = function () {
+    var scene = this.scene;
+
+    // Use Coder A's getActivePlatforms helper if available,
+    // otherwise fall back to scanning the platform group directly.
+    var active;
+    if (AP.PlatformCollapse && typeof AP.PlatformCollapse.getActivePlatforms === 'function') {
+      active = AP.PlatformCollapse.getActivePlatforms(scene.platforms);
+    } else {
+      // Fallback: scan the group ourselves
+      var children = scene.platforms.getChildren();
+      active = [];
+      for (var i = 0; i < children.length; i++) {
+        var c = children[i];
+        if (c.active && c.visible && c.texture && c.texture.key === 'platform') {
+          if (c._collapseState === 'stable') {
+            active.push(c);
+          }
+        }
+      }
+    }
+
+    if (active.length === 0) return; // nothing left to destroy
+
+    var idx = Math.floor(Math.random() * active.length);
+    var target = active[idx];
+
+    // Use Coder A's PlatformCollapse.startCollapse(scene, plat) interface
+    if (AP.PlatformCollapse && typeof AP.PlatformCollapse.startCollapse === 'function') {
+      AP.PlatformCollapse.startCollapse(scene, target);
+    }
+  };
+
+  // -- Vacuum Vent --
+  ChaosEventSystem.prototype._startVacuumVent = function () {
+    // Pick a random cardinal direction
+    var dirs = [
+      { x: 1,  y: 0 },   // right
+      { x: -1, y: 0 },   // left
+      { x: 0,  y: -1 },  // up
+      { x: 0,  y: 1 }    // down
+    ];
+    var pick = dirs[Math.floor(Math.random() * dirs.length)];
+    this._vacuumDir.x = pick.x;
+    this._vacuumDir.y = pick.y;
+  };
+
+  ChaosEventSystem.prototype._stopVacuumVent = function () {
+    this._vacuumDir.x = 0;
+    this._vacuumDir.y = 0;
+  };
+
+  ChaosEventSystem.prototype._updateVacuumVent = function () {
+    if (!this.isActive('vacuumVent')) return;
+
+    var playerList = this._getPlayerList();
+    for (var i = 0; i < playerList.length; i++) {
+      var p = playerList[i];
+      if (p && p.active && p.body) {
+        // Apply as a per-frame velocity nudge (accumulates, feels like wind)
+        var dt = this._delta / 1000;
+        p.body.velocity.x += this._vacuumDir.x * VACUUM_FORCE * dt;
+        p.body.velocity.y += this._vacuumDir.y * VACUUM_FORCE * dt;
+      }
+    }
+  };
+
+  /**
+   * Returns an array of player sprites from the scene.
+   * Handles the current single-player setup (this.player)
+   * as well as the future multi-player array/group (this.players).
+   */
+  ChaosEventSystem.prototype._getPlayerList = function () {
+    var scene = this.scene;
+
+    // Multi-player group or array (Phase 2+)
+    if (scene.players) {
+      return scene.players.getChildren
+        ? scene.players.getChildren()
+        : scene.players;
+    }
+
+    // Single player fallback (Phase 1 scaffold)
+    if (scene.player && scene.player.active) {
+      return [scene.player];
+    }
+
+    return [];
+  };
+
+  // -------------------------------------------------------
+  // Announcement text
+  // -------------------------------------------------------
+  ChaosEventSystem.prototype._showAnnouncement = function (eventName, time) {
+    var scene = this.scene;
+    var label = EVENT_LABELS[eventName] || eventName;
+    var size = AP.gameSize;
+
+    if (!this._announceText) {
+      this._announceText = scene.add.text(
+        size / 2,
+        size * 0.3,
+        '',
+        {
+          fontFamily: 'monospace',
+          fontSize: '28px',
+          color: '#ff00ff',
+          stroke: '#000000',
+          strokeThickness: 4,
+          align: 'center'
+        }
+      );
+      this._announceText.setOrigin(0.5);
+      this._announceText.setDepth(1000); // above everything including blackout
+    }
+
+    this._announceText.setText(label);
+    this._announceText.setVisible(true);
+    this._announceText.setAlpha(1);
+    this._announceEndTime = time + ANNOUNCE_DURATION;
+  };
+
+  ChaosEventSystem.prototype._updateAnnouncement = function (time) {
+    if (!this._announceText || !this._announceText.visible) return;
+
+    if (time >= this._announceEndTime) {
+      this._announceText.setVisible(false);
+      return;
+    }
+
+    // Fade out over the last 500ms
+    var remaining = this._announceEndTime - time;
+    if (remaining < 500) {
+      this._announceText.setAlpha(remaining / 500);
+    }
+  };
+
+  // -------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------
+  ChaosEventSystem.prototype._jitter = function () {
+    return (Math.random() - 0.5) * EVENT_INTERVAL_VARIANCE;
+  };
+
+  // -------------------------------------------------------
+  // Expose on AP namespace
+  // -------------------------------------------------------
+  // Preserve any static helpers already placed on AP.ChaosEventSystem
+  // by other files (e.g. Coder A's getActivePlatforms).
+  var existing = AP.ChaosEventSystem || {};
+  AP.ChaosEventSystem = ChaosEventSystem;
+
+  // Copy static properties from the previous object onto the constructor
+  var keys = Object.keys(existing);
+  for (var k = 0; k < keys.length; k++) {
+    if (!ChaosEventSystem[keys[k]]) {
+      ChaosEventSystem[keys[k]] = existing[keys[k]];
+    }
+  }
+
+})();


### PR DESCRIPTION
## Summary
Team 2's Phase 2 implementation: platform collapse mechanics and chaos event system. Both systems use flag-based interfaces for loose coupling with Phase 3 systems (GravitySystem, BlackHole).

## What was built

### Platform Collapse (`js/entities/Platform.js`)
Namespace: `AP.PlatformCollapse`

**Public API:**
- `AP.PlatformCollapse.initCollapseState(plat, index)` — attach collapse tracking to a platform sprite. Called once per platform in GameScene `create()`.
- `AP.PlatformCollapse.startCollapse(scene, plat)` — begin 2-second warning phase (red tint + alpha blink). Safe to call multiple times; no-ops if platform is not in `stable` state.
- `AP.PlatformCollapse.collapse(plat)` — instantly disable physics body, hide sprite, mark as `collapsed`.
- `AP.PlatformCollapse.getActivePlatforms(platformGroup)` — returns array of non-collapsed platform sprites (excludes boundary segments).

**Constants exposed:**
- `COLLAPSE_WARNING_DURATION` = 2000ms
- `COLLAPSE_FLASH_INTERVAL` = 150ms
- `FIRST_COLLAPSE_DELAY` = 20000ms (~20s into match)
- `COLLAPSE_STAGGER_INTERVAL` = 8000ms (between successive collapses)

**Collapse state machine per platform:**
`stable` → `warning` (2s, red tint + blink) → `collapsed` (body disabled, invisible)

**Priority tiers (outer first, central last):**
- Tier 1 (outer): bottom-left, bottom-right, upper-left, upper-right
- Tier 2 (mid): center-low, mid-left, mid-right
- Tier 3 (central): center-mid, top-center

**GameScene hookpoints filled:**
- `create()`: initializes collapse state on each platform, builds shuffle-sorted collapse queue
- `updatePlatforms(delta)`: tracks match time, triggers staggered collapses from queue, runs warning flash animation

---

### Chaos Event System (`js/systems/ChaosEventSystem.js`)
Constructor: `new AP.ChaosEventSystem(scene)`
Instance stored at: `scene.chaosSystem`

**Public API:**
- `chaosSystem.isActive(eventName)` → `boolean` — returns true while the named event is in effect. Phase 3 systems should poll this each frame.
- `chaosSystem.getVacuumDir()` → `{x, y}` — current vacuum vent direction vector (or `{0,0}`)
- `chaosSystem.getVacuumForce()` → `number` — vacuum force magnitude (180 px/s)
- `chaosSystem.update(time, delta)` — called from GameScene each frame

**5 Event Types (fire every ~20s ± 4s jitter):**

| Event | Duration | What it does | Phase 3 integration |
|-------|----------|-------------|---------------------|
| `gravitySurge` | 4s | Sets flag only | GravitySystem reads `isActive('gravitySurge')`, doubles pull |
| `blackout` | 3s | Black overlay at 0.92 opacity, depth 900 | HUD elements should be depth > 900 to stay visible |
| `meteorStrike` | instant | Calls `AP.PlatformCollapse.startCollapse()` on random active platform | Already wired to Coder A's interface |
| `eventHorizonFlash` | 2s | Sets flag only | BlackHole reads `isActive('eventHorizonFlash')`, doubles size |
| `vacuumVent` | 3s | Applies directional velocity to all players (cardinal direction) | Uses delta-time, force = 180 px/s |

**Event names for `isActive()` queries:**
`'gravitySurge'`, `'blackout'`, `'meteorStrike'`, `'eventHorizonFlash'`, `'vacuumVent'`

**GameScene hookpoints filled:**
- `setupChaos()`: creates `this.chaosSystem = new AP.ChaosEventSystem(this)`
- `updateChaos(time, delta)`: calls `this.chaosSystem.update(time, delta)`

---

## Phase 3 integration guide for other teams

### Team 1 (Bullets + Powerups)
- No direct dependencies on Team 2's code in Phase 2
- Phase 3: bullets near collapsing platforms — no special handling needed (platform body disables cleanly)

### Team 3 (Black Hole + Gravity)
- **GravitySystem** should check `scene.chaosSystem.isActive('gravitySurge')` each frame and double pull force when true
- **BlackHole** should check `scene.chaosSystem.isActive('eventHorizonFlash')` each frame and double visual size when true
- Both need a reference to `scene.chaosSystem` — available as `this.chaosSystem` in GameScene

### Collider notes
- Collapsed platforms have `body.enable = false` and `active = false` — colliders will skip them automatically
- Blackout overlay is at depth 900, announcements at depth 1000 — place HUD elements accordingly

## Files changed
- `js/entities/Platform.js` — **new** (110 lines)
- `js/systems/ChaosEventSystem.js` — **new** (354 lines)
- `js/scenes/GameScene.js` — modified (added collapse + chaos hookpoints)
- `index.html` — modified (2 script tags added)

## Test plan
- [ ] Open index.html — game loads without console errors
- [ ] Wait ~20s — first platform starts flashing red, collapses after 2s
- [ ] Outer platforms (corners) collapse before central ones
- [ ] Chaos event announcements appear in magenta monospace text
- [ ] Blackout: screen goes dark for 3s, announcement still visible
- [ ] Vacuum Vent: player gets pushed in a direction for 3s
- [ ] Meteor Strike: random platform starts collapsing immediately
- [ ] No double-collapse when Meteor Strike hits a platform already in the queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)